### PR TITLE
Update Interface versions for 9.0.5 and 1.13.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
 
       - uses: BigWigsMods/packager@master
         with:
-          args: -g 1.13.5
+          args: -g 1.13.6
 
       - uses: BigWigsMods/packager@master

--- a/BlockChinese.toc
+++ b/BlockChinese.toc
@@ -1,8 +1,8 @@
 #@retail@
-## Interface: 90002
+## Interface: 90005
 #@end-retail@
 #@non-retail@
-# ## Interface: 11305
+# ## Interface: 11306
 #@end-non-retail@
 ## Version: @project-version@
 ## Title: BlockChinese


### PR DESCRIPTION
New patches are out for classic (was 1.13.5, now 1.13.6) and retail (was 9.0.2, now 9.0.5). This PR updates:

- the `## Interface: ` versions in the TOC file
- the specified classic version in the GH action release.yml workflow file

If you're okay with this PR, make sure to merge it and push a new tag (e.g. `v2.1`).